### PR TITLE
Updated OfxDatGui to be compatible with OpenFrameworks version 0.10.1

### DIFF
--- a/ofx_0.10.1.patch
+++ b/ofx_0.10.1.patch
@@ -1,0 +1,178 @@
+diff --git a/src/libs/ofxSmartFont/ofxSmartFont.cpp b/src/libs/ofxSmartFont/ofxSmartFont.cpp
+index 49d13da..71ca6af 100644
+--- a/src/libs/ofxSmartFont/ofxSmartFont.cpp
++++ b/src/libs/ofxSmartFont/ofxSmartFont.cpp
+@@ -23,28 +23,28 @@
+ 
+ 
+ #include "ofxSmartFont.h"
+-vector<shared_ptr<ofxSmartFont>> ofxSmartFont::mFonts;
++std::vector<std::shared_ptr<ofxSmartFont>> ofxSmartFont::mFonts;
+ 
+ /*
+     instance methods
+ */
+ 
+-void ofxSmartFont::draw(string s, int x, int y)
++void ofxSmartFont::draw(std::string s, int x, int y)
+ {
+     ttf.drawString(s, x, y);
+ }
+ 
+-string ofxSmartFont::name()
++std::string ofxSmartFont::name()
+ {
+     return mName;
+ }
+ 
+-void ofxSmartFont::name(string name)
++void ofxSmartFont::name(std::string name)
+ {
+     mName = name;
+ }
+ 
+-string ofxSmartFont::file()
++std::string ofxSmartFont::file()
+ {
+     return mFile;
+ }
+@@ -54,17 +54,17 @@ int ofxSmartFont::size()
+     return mSize;
+ }
+ 
+-ofRectangle ofxSmartFont::rect(string s, int x, int y)
++ofRectangle ofxSmartFont::rect(std::string s, int x, int y)
+ {
+     return ttf.getStringBoundingBox(s, x, y);
+ }
+ 
+-float ofxSmartFont::width(string s, int x, int y)
++float ofxSmartFont::width(std::string s, int x, int y)
+ {
+     return ttf.getStringBoundingBox(s, x, y).width;
+ }
+ 
+-float ofxSmartFont::height(string s, int x, int y)
++float ofxSmartFont::height(std::string s, int x, int y)
+ {
+     return ttf.getStringBoundingBox(s, x, y).height;
+ }
+@@ -78,7 +78,7 @@ float ofxSmartFont::getLineHeight()
+     static methods
+ */
+ 
+-shared_ptr<ofxSmartFont> ofxSmartFont::add(string file, int size, string name)
++std::shared_ptr<ofxSmartFont> ofxSmartFont::add(std::string file, int size, std::string name)
+ {
+     for(auto f:mFonts){
+         if (f->file()==file && f->size()==size){
+@@ -87,13 +87,13 @@ shared_ptr<ofxSmartFont> ofxSmartFont::add(string file, int size, string name)
+         }
+     }
+     struct make_shared_sf : public ofxSmartFont {
+-        make_shared_sf(string file, int size, string name) : ofxSmartFont(file, size, name){}
++        make_shared_sf(std::string file, int size, std::string name) : ofxSmartFont(file, size, name){}
+     };
+-    mFonts.push_back(make_shared<make_shared_sf>(file, size, name));
++    mFonts.push_back(std::make_shared<make_shared_sf>(file, size, name));
+     return mFonts.back();
+ }
+ 
+-shared_ptr<ofxSmartFont> ofxSmartFont::get(string name)
++std::shared_ptr<ofxSmartFont> ofxSmartFont::get(std::string name)
+ {
+     for(auto f:mFonts){
+         if (f->name()==name) return f;
+@@ -102,7 +102,7 @@ shared_ptr<ofxSmartFont> ofxSmartFont::get(string name)
+     return nullptr;
+ }
+ 
+-shared_ptr<ofxSmartFont> ofxSmartFont::get(string name, int size)
++std::shared_ptr<ofxSmartFont> ofxSmartFont::get(std::string name, int size)
+ {
+     for(auto f:mFonts){
+         if (f->file().find(name) != std::string::npos && f->size()==size){
+@@ -113,7 +113,7 @@ shared_ptr<ofxSmartFont> ofxSmartFont::get(string name, int size)
+     return nullptr;
+ }
+ 
+-shared_ptr<ofxSmartFont> ofxSmartFont::get(vector<string> keys, int size)
++std::shared_ptr<ofxSmartFont> ofxSmartFont::get(std::vector<std::string> keys, int size)
+ {
+     for(auto f:mFonts){
+         bool match = true;
+@@ -141,8 +141,8 @@ void ofxSmartFont::list()
+     log("----------------------------------");
+ }
+ 
+-void ofxSmartFont::log(string msg)
++void ofxSmartFont::log(std::string msg)
+ {
+-    cout << "ofxSmartFont :: "<< msg << endl;
++    std::cout << "ofxSmartFont :: "<< msg << std::endl;
+ }
+ 
+diff --git a/src/libs/ofxSmartFont/ofxSmartFont.h b/src/libs/ofxSmartFont/ofxSmartFont.h
+index 47f6cd1..06c2cff 100644
+--- a/src/libs/ofxSmartFont/ofxSmartFont.h
++++ b/src/libs/ofxSmartFont/ofxSmartFont.h
+@@ -32,31 +32,31 @@ class ofxSmartFont {
+         instance methods
+     */
+     
+-        string file();
++        std::string file();
+         int size();
+-        string name();
+-        void name(string name);
+-        void draw(string s, int x, int y);
++        std::string name();
++        void name(std::string name);
++        void draw(std::string s, int x, int y);
+     
+-        ofRectangle rect(string s, int x=0, int y=0);
+-        float width(string s, int x=0, int y=0);
+-        float height(string s, int x=0, int y=0);
++        ofRectangle rect(std::string s, int x=0, int y=0);
++        float width(std::string s, int x=0, int y=0);
++        float height(std::string s, int x=0, int y=0);
+         float getLineHeight();
+     
+     /*
+         static methods
+     */
+-        static shared_ptr<ofxSmartFont> add(string file, int size, string name = "");
+-        static shared_ptr<ofxSmartFont> get(string name);
+-        static shared_ptr<ofxSmartFont> get(string name, int size);
+-        static shared_ptr<ofxSmartFont> get(vector<string> keys, int size);
++        static std::shared_ptr<ofxSmartFont> add(std::string file, int size, std::string name = "");
++        static std::shared_ptr<ofxSmartFont> get(std::string name);
++        static std::shared_ptr<ofxSmartFont> get(std::string name, int size);
++        static std::shared_ptr<ofxSmartFont> get(std::vector<std::string> keys, int size);
+         static void list();
+     
+-        static vector<shared_ptr<ofxSmartFont>> mFonts;
++        static std::vector<std::shared_ptr<ofxSmartFont>> mFonts;
+     
+     private:
+     
+-        ofxSmartFont(string file, int size, string name)
++        ofxSmartFont(std::string file, int size, std::string name)
+         {
+             mSize = size;
+             mFile = file;
+@@ -72,11 +72,11 @@ class ofxSmartFont {
+             }
+         }
+     
+-        static void log(string msg);
++        static void log(std::string msg);
+ 
+         int mSize;
+-        string mFile;
+-        string mName;
++        std::string mFile;
++        std::string mName;
+         ofTrueTypeFont ttf;
+     
+ };

--- a/src/libs/ofxSmartFont/ofxSmartFont.cpp
+++ b/src/libs/ofxSmartFont/ofxSmartFont.cpp
@@ -23,28 +23,28 @@
 
 
 #include "ofxSmartFont.h"
-vector<shared_ptr<ofxSmartFont>> ofxSmartFont::mFonts;
+std::vector<std::shared_ptr<ofxSmartFont>> ofxSmartFont::mFonts;
 
 /*
     instance methods
 */
 
-void ofxSmartFont::draw(string s, int x, int y)
+void ofxSmartFont::draw(std::string s, int x, int y)
 {
     ttf.drawString(s, x, y);
 }
 
-string ofxSmartFont::name()
+std::string ofxSmartFont::name()
 {
     return mName;
 }
 
-void ofxSmartFont::name(string name)
+void ofxSmartFont::name(std::string name)
 {
     mName = name;
 }
 
-string ofxSmartFont::file()
+std::string ofxSmartFont::file()
 {
     return mFile;
 }
@@ -54,17 +54,17 @@ int ofxSmartFont::size()
     return mSize;
 }
 
-ofRectangle ofxSmartFont::rect(string s, int x, int y)
+ofRectangle ofxSmartFont::rect(std::string s, int x, int y)
 {
     return ttf.getStringBoundingBox(s, x, y);
 }
 
-float ofxSmartFont::width(string s, int x, int y)
+float ofxSmartFont::width(std::string s, int x, int y)
 {
     return ttf.getStringBoundingBox(s, x, y).width;
 }
 
-float ofxSmartFont::height(string s, int x, int y)
+float ofxSmartFont::height(std::string s, int x, int y)
 {
     return ttf.getStringBoundingBox(s, x, y).height;
 }
@@ -78,7 +78,7 @@ float ofxSmartFont::getLineHeight()
     static methods
 */
 
-shared_ptr<ofxSmartFont> ofxSmartFont::add(string file, int size, string name)
+std::shared_ptr<ofxSmartFont> ofxSmartFont::add(std::string file, int size, std::string name)
 {
     for(auto f:mFonts){
         if (f->file()==file && f->size()==size){
@@ -87,13 +87,13 @@ shared_ptr<ofxSmartFont> ofxSmartFont::add(string file, int size, string name)
         }
     }
     struct make_shared_sf : public ofxSmartFont {
-        make_shared_sf(string file, int size, string name) : ofxSmartFont(file, size, name){}
+        make_shared_sf(std::string file, int size, std::string name) : ofxSmartFont(file, size, name){}
     };
-    mFonts.push_back(make_shared<make_shared_sf>(file, size, name));
+    mFonts.push_back(std::make_shared<make_shared_sf>(file, size, name));
     return mFonts.back();
 }
 
-shared_ptr<ofxSmartFont> ofxSmartFont::get(string name)
+std::shared_ptr<ofxSmartFont> ofxSmartFont::get(std::string name)
 {
     for(auto f:mFonts){
         if (f->name()==name) return f;
@@ -102,7 +102,7 @@ shared_ptr<ofxSmartFont> ofxSmartFont::get(string name)
     return nullptr;
 }
 
-shared_ptr<ofxSmartFont> ofxSmartFont::get(string name, int size)
+std::shared_ptr<ofxSmartFont> ofxSmartFont::get(std::string name, int size)
 {
     for(auto f:mFonts){
         if (f->file().find(name) != std::string::npos && f->size()==size){
@@ -113,7 +113,7 @@ shared_ptr<ofxSmartFont> ofxSmartFont::get(string name, int size)
     return nullptr;
 }
 
-shared_ptr<ofxSmartFont> ofxSmartFont::get(vector<string> keys, int size)
+std::shared_ptr<ofxSmartFont> ofxSmartFont::get(std::vector<std::string> keys, int size)
 {
     for(auto f:mFonts){
         bool match = true;
@@ -141,8 +141,8 @@ void ofxSmartFont::list()
     log("----------------------------------");
 }
 
-void ofxSmartFont::log(string msg)
+void ofxSmartFont::log(std::string msg)
 {
-    cout << "ofxSmartFont :: "<< msg << endl;
+    std::cout << "ofxSmartFont :: "<< msg << std::endl;
 }
 

--- a/src/libs/ofxSmartFont/ofxSmartFont.h
+++ b/src/libs/ofxSmartFont/ofxSmartFont.h
@@ -32,31 +32,31 @@ class ofxSmartFont {
         instance methods
     */
     
-        string file();
+        std::string file();
         int size();
-        string name();
-        void name(string name);
-        void draw(string s, int x, int y);
+        std::string name();
+        void name(std::string name);
+        void draw(std::string s, int x, int y);
     
-        ofRectangle rect(string s, int x=0, int y=0);
-        float width(string s, int x=0, int y=0);
-        float height(string s, int x=0, int y=0);
+        ofRectangle rect(std::string s, int x=0, int y=0);
+        float width(std::string s, int x=0, int y=0);
+        float height(std::string s, int x=0, int y=0);
         float getLineHeight();
     
     /*
         static methods
     */
-        static shared_ptr<ofxSmartFont> add(string file, int size, string name = "");
-        static shared_ptr<ofxSmartFont> get(string name);
-        static shared_ptr<ofxSmartFont> get(string name, int size);
-        static shared_ptr<ofxSmartFont> get(vector<string> keys, int size);
+        static std::shared_ptr<ofxSmartFont> add(std::string file, int size, std::string name = "");
+        static std::shared_ptr<ofxSmartFont> get(std::string name);
+        static std::shared_ptr<ofxSmartFont> get(std::string name, int size);
+        static std::shared_ptr<ofxSmartFont> get(std::vector<std::string> keys, int size);
         static void list();
     
-        static vector<shared_ptr<ofxSmartFont>> mFonts;
+        static std::vector<std::shared_ptr<ofxSmartFont>> mFonts;
     
     private:
     
-        ofxSmartFont(string file, int size, string name)
+        ofxSmartFont(std::string file, int size, std::string name)
         {
             mSize = size;
             mFile = file;
@@ -72,11 +72,11 @@ class ofxSmartFont {
             }
         }
     
-        static void log(string msg);
+        static void log(std::string msg);
 
         int mSize;
-        string mFile;
-        string mName;
+        std::string mFile;
+        std::string mName;
         ofTrueTypeFont ttf;
     
 };


### PR DESCRIPTION
When trying to update Magic-Sand to be compatible with OpenFrameworks 0.10.1, OfxDatGui was causing problems, as this fork of ofxDatGui had methods required by Magic-Sand (setOptions, for example), but was missing some bugfixes made to bring ofxDatGui up to work with 0.10.1 (https://github.com/braitsch/ofxDatGui/issues/148). I've re-implemented that bugfix, so that this specific fork for Magic-Sand is 0.10.1 compatible.